### PR TITLE
Add jitter option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,15 +48,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
+name = "fastrand"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "gimli"
@@ -95,7 +84,7 @@ dependencies = [
 name = "named-retry"
 version = "0.3.0"
 dependencies = [
- "rand",
+ "fastrand",
  "tokio",
  "tracing",
 ]
@@ -122,15 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,36 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -253,30 +203,3 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,9 +72,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "memchr"
@@ -78,6 +95,7 @@ dependencies = [
 name = "named-retry"
 version = "0.2.1"
 dependencies = [
+ "rand",
  "tokio",
  "tracing",
 ]
@@ -104,6 +122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +146,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -196,3 +253,30 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "named-retry"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rand",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.24.2", features = ["time"] }
 tracing = "0.1.32"
-rand = "0.8.5"
+fastrand = "2.2.0"
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["rt", "macros", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "named-retry"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Eric Zhang <ekzhang1@gmail.com>"]
 license = "MIT"
 description = "A simple utility for retrying fallible asynchronous operations."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 authors = ["Eric Zhang <ekzhang1@gmail.com>"]
 license = "MIT"
 description = "A simple utility for retrying fallible asynchronous operations."
-repository = "https://github.com/modal-labs/blobnet"
+repository = "https://github.com/modal-labs/named-retry"
 documentation = "https://docs.rs/named-retry"
 keywords = ["retry", "async"]
 categories = ["development-tools::debugging", "asynchronous", "network-programming"]
@@ -14,6 +14,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.24.2", features = ["time"] }
 tracing = "0.1.32"
+rand = "0.8.5"
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["rt", "macros", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ use named_retry::Retry;
 let retry = Retry::new("test")
     .attempts(5)
     .base_delay(Duration::from_secs(1))
-    .delay_factor(2.0);
+    .delay_factor(2.0)
+    .jitter(true);
 
 let result = retry.run(|| async { Ok::<_, ()>("done!") }).await;
 assert_eq!(result, Ok("done!"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl Retry {
     fn apply_jitter(&self, delay: Duration) -> Duration {
         if self.enable_jitter {
             // [0.5, 1.0)
-            delay.mul_f64(0.5 + rand::random::<f64>() / 2.0)
+            delay.mul_f64(0.5 + fastrand::f64() / 2.0)
         } else {
             delay
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ pub struct Retry {
 
     /// Exponential factor to increase the delay by on each attempt.
     pub delay_factor: f64,
+
+    /// If true, the delay will be selected randomly from the range [delay/2, delay).
+    pub enable_jitter: bool,
 }
 
 impl Retry {
@@ -36,6 +39,7 @@ impl Retry {
             attempts: 3,
             base_delay: Duration::ZERO,
             delay_factor: 1.0,
+            enable_jitter: false,
         }
     }
 
@@ -55,6 +59,21 @@ impl Retry {
     pub const fn delay_factor(mut self, delay_factor: f64) -> Self {
         self.delay_factor = delay_factor;
         self
+    }
+
+    /// Enable jitter.
+    pub const fn jitter(mut self, enabled: bool) -> Self {
+        self.enable_jitter = enabled;
+        self
+    }
+
+    fn apply_jitter(&self, delay: Duration) -> Duration {
+        if self.enable_jitter {
+            // [0.5, 1.0)
+            delay.mul_f64(0.5 + rand::random::<f64>() / 2.0)
+        } else {
+            delay
+        }
     }
 
     /// Run a falliable asynchronous function using this retry configuration.
@@ -77,7 +96,7 @@ impl Retry {
                 Err(err) if i == self.attempts - 1 => return Err(err),
                 Err(err) => {
                     warn!(?err, "failed retryable operation {}, retrying", self.name);
-                    time::sleep(delay).await;
+                    time::sleep(self.apply_jitter(delay)).await;
                     delay = delay.mul_f64(self.delay_factor);
                 }
             }
@@ -151,6 +170,33 @@ mod tests {
             });
         let result = task.await;
         assert_eq!(count, 4);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_retry_with_jitter() {
+        let start = Instant::now();
+
+        let mut count = 0;
+        // Earliest possible retry is 0s, 50ms, 525ms, 5.525s
+        let task = Retry::new("test_jitter")
+            .attempts(4)
+            .base_delay(Duration::from_millis(100))
+            .delay_factor(10.0)
+            .jitter(true)
+            .run(|| {
+                count += 1;
+                async {
+                    println!("elapsed = {:?}", start.elapsed());
+                    if start.elapsed() < Duration::from_millis(500) {
+                        Err::<(), ()>(())
+                    } else {
+                        Ok(())
+                    }
+                }
+            });
+        let result = task.await;
+        assert_eq!(count, 3);
         assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
Adds an opt-in jitter option, which selects a time uniformly randomly from the interval [0.5, 1.0)*delay each time it pauses. The randomness is applied only to the sleep, and doesn't affect how much future delays increase by. 