### PR TITLE
Add custom error handler via on_error builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ let retry = Retry::new("test")
 let result = retry.run(async || { Ok::<_, ()>("done!") }).await;
 assert_eq!(result, Ok("done!"));
 ```
+
+By default, failed attempts are logged at `warn` level via `tracing`. Use `on_error` to customize error handling, for example when polling where some errors are expected:
+
+```rust
+use tracing::debug;
+
+let result = Retry::new("poll")
+    .attempts(10)
+    .base_delay(Duration::from_secs(1))
+    .on_error(|err, _attempt, _total| {
+        debug!(?err, "not ready yet");
+    })
+    .run(async || { Ok::<_, ()>("done!") })
+    .await;
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ assert_eq!(result, Ok("done!"));
 By default, failed attempts are logged at `warn` level via `tracing`. Use `on_error` to customize error handling, for example when polling where some errors are expected:
 
 ```rust
+use std::ops::ControlFlow;
 use tracing::debug;
 
 let result = Retry::new("poll")
@@ -26,7 +27,10 @@ let result = Retry::new("poll")
     .base_delay(Duration::from_secs(1))
     .on_error(|err, _attempt, _total| {
         debug!(?err, "not ready yet");
+        ControlFlow::Continue(())
     })
     .run(async || { Ok::<_, ()>("done!") })
     .await;
 ```
+
+The error handler can also abort retries early by returning `ControlFlow::Break(err)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,28 +75,80 @@ impl Retry {
         }
     }
 
+    /// Set a custom error handler, returning a [`RetryWith`] that can be
+    /// [`run`](RetryWith::run).
+    ///
+    /// The handler receives the error (by value), the 1-indexed attempt
+    /// number that just failed, and the total number of attempts configured.
+    ///
+    /// This should be the last builder method before calling `run`.
+    pub fn on_error<F>(self, handler: F) -> RetryWith<F> {
+        RetryWith {
+            inner: self,
+            on_error: handler,
+        }
+    }
+
     /// Run a falliable asynchronous function using this retry configuration.
+    ///
+    /// Failed attempts are logged at `warn` level via `tracing`. To customize
+    /// error handling, use [`on_error`](Self::on_error) instead.
     ///
     /// Panics if the number of attempts is set to `0`, or the base delay is
     /// incorrectly set to a negative duration.
     pub async fn run<T, E: Debug>(
         self,
-        mut func: impl AsyncFnMut() -> Result<T, E>,
+        func: impl AsyncFnMut() -> Result<T, E>,
     ) -> Result<T, E> {
-        assert!(self.attempts > 0, "attempts must be greater than 0");
+        let name = self.name;
+        self.on_error(|err: E, _attempt, _total| {
+            warn!(?err, "failed retryable operation {}, retrying", name);
+        })
+        .run(func)
+        .await
+    }
+}
+
+/// A [`Retry`] paired with a custom error handler. Created by
+/// [`Retry::on_error`].
+pub struct RetryWith<F> {
+    inner: Retry,
+    on_error: F,
+}
+
+impl<F> RetryWith<F> {
+    /// Run a falliable asynchronous function using this retry configuration.
+    ///
+    /// Unlike [`Retry::run`], this does not require `E: Debug` since error
+    /// formatting is delegated to the custom error handler.
+    ///
+    /// Panics if the number of attempts is set to `0`, or the base delay is
+    /// incorrectly set to a negative duration.
+    pub async fn run<T, E>(
+        self,
+        mut func: impl AsyncFnMut() -> Result<T, E>,
+    ) -> Result<T, E>
+    where
+        F: FnMut(E, u32, u32),
+    {
+        let Self {
+            inner,
+            mut on_error,
+        } = self;
+        assert!(inner.attempts > 0, "attempts must be greater than 0");
         assert!(
-            self.base_delay >= Duration::ZERO && self.delay_factor >= 0.0,
+            inner.base_delay >= Duration::ZERO && inner.delay_factor >= 0.0,
             "retry delay cannot be negative"
         );
-        let mut delay = self.base_delay;
-        for i in 0..self.attempts {
+        let mut delay = inner.base_delay;
+        for i in 0..inner.attempts {
             match func().await {
                 Ok(value) => return Ok(value),
-                Err(err) if i == self.attempts - 1 => return Err(err),
+                Err(err) if i == inner.attempts - 1 => return Err(err),
                 Err(err) => {
-                    warn!(?err, "failed retryable operation {}, retrying", self.name);
-                    time::sleep(self.apply_jitter(delay)).await;
-                    delay = delay.mul_f64(self.delay_factor);
+                    on_error(err, i + 1, inner.attempts);
+                    time::sleep(inner.apply_jitter(delay)).await;
+                    delay = delay.mul_f64(inner.delay_factor);
                 }
             }
         }
@@ -167,6 +219,65 @@ mod tests {
             });
         let result = task.await;
         assert_eq!(count, 4);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn custom_error_handler() {
+        let mut errors: Vec<(u32, u32)> = Vec::new();
+        let mut count = 0;
+        let result = Retry::new("test")
+            .on_error(|_err: &str, attempt, total| {
+                errors.push((attempt, total));
+            })
+            .run(async || {
+                count += 1;
+                if count < 3 {
+                    Err::<(), &str>("boom")
+                } else {
+                    Ok(())
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(errors, vec![(1, 3), (2, 3)]);
+    }
+
+    #[tokio::test]
+    async fn silent_error_handler() {
+        let mut count = 0;
+        let result = Retry::new("silent")
+            .on_error(|_: (), _, _| {})
+            .run(async || {
+                count += 1;
+                if count < 3 {
+                    Err::<(), ()>(())
+                } else {
+                    Ok(())
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn error_handler_no_debug_bound() {
+        struct OpaqueError;
+
+        let mut count = 0;
+        let result = Retry::new("opaque")
+            .attempts(2)
+            .on_error(|_: OpaqueError, _, _| {})
+            .run(async || {
+                count += 1;
+                if count < 2 {
+                    Err::<(), _>(OpaqueError)
+                } else {
+                    Ok(())
+                }
+            })
+            .await;
         assert!(result.is_ok());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Utilities for retrying falliable, asynchronous operations.
 
 use std::fmt::Debug;
+use std::ops::ControlFlow;
 use std::time::Duration;
 
 use tokio::time;
@@ -80,6 +81,8 @@ impl Retry {
     ///
     /// The handler receives the error (by value), the 1-indexed attempt
     /// number that just failed, and the total number of attempts configured.
+    /// It returns [`ControlFlow::Continue`] to retry or [`ControlFlow::Break`]
+    /// with the error to stop immediately.
     ///
     /// This should be the last builder method before calling `run`.
     pub fn on_error<F>(self, handler: F) -> RetryWith<F> {
@@ -100,6 +103,7 @@ impl Retry {
         let name = self.name;
         self.on_error(|err: E, _attempt, _total| {
             warn!(?err, "failed retryable operation {}, retrying", name);
+            ControlFlow::Continue(())
         })
         .run(func)
         .await
@@ -119,11 +123,14 @@ impl<F> RetryWith<F> {
     /// Unlike [`Retry::run`], this does not require `E: Debug` since error
     /// formatting is delegated to the custom error handler.
     ///
+    /// The error handler can return [`ControlFlow::Break`] to stop retrying
+    /// early, or [`ControlFlow::Continue`] to proceed with the next attempt.
+    ///
     /// Panics if the number of attempts is set to `0`, or the base delay is
     /// incorrectly set to a negative duration.
     pub async fn run<T, E>(self, mut func: impl AsyncFnMut() -> Result<T, E>) -> Result<T, E>
     where
-        F: FnMut(E, u32, u32),
+        F: FnMut(E, u32, u32) -> ControlFlow<E>,
     {
         let Self {
             inner,
@@ -140,7 +147,10 @@ impl<F> RetryWith<F> {
                 Ok(value) => return Ok(value),
                 Err(err) if i == inner.attempts - 1 => return Err(err),
                 Err(err) => {
-                    on_error(err, i + 1, inner.attempts);
+                    match on_error(err, i + 1, inner.attempts) {
+                        ControlFlow::Break(err) => return Err(err),
+                        ControlFlow::Continue(()) => {}
+                    }
                     time::sleep(inner.apply_jitter(delay)).await;
                     delay = delay.mul_f64(inner.delay_factor);
                 }
@@ -157,6 +167,7 @@ mod tests {
     use tokio::time::Instant;
 
     use super::Retry;
+    use std::ops::ControlFlow;
 
     #[tokio::test]
     #[should_panic]
@@ -223,6 +234,7 @@ mod tests {
         let result = Retry::new("test")
             .on_error(|_err: &str, attempt, total| {
                 errors.push((attempt, total));
+                ControlFlow::Continue(())
             })
             .run(async || {
                 count += 1;
@@ -241,7 +253,7 @@ mod tests {
     async fn silent_error_handler() {
         let mut count = 0;
         let result = Retry::new("silent")
-            .on_error(|_: (), _, _| {})
+            .on_error(|_: (), _, _| ControlFlow::Continue(()))
             .run(async || {
                 count += 1;
                 if count < 3 { Err::<(), ()>(()) } else { Ok(()) }
@@ -258,7 +270,7 @@ mod tests {
         let mut count = 0;
         let result = Retry::new("opaque")
             .attempts(2)
-            .on_error(|_: OpaqueError, _, _| {})
+            .on_error(|_: OpaqueError, _, _| ControlFlow::Continue(()))
             .run(async || {
                 count += 1;
                 if count < 2 {
@@ -269,6 +281,31 @@ mod tests {
             })
             .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn error_handler_aborts_early() {
+        let mut count = 0;
+        let result = Retry::new("abort")
+            .attempts(5)
+            .on_error(|err: String, _attempt, _total| {
+                if err == "permanent" {
+                    ControlFlow::Break(err)
+                } else {
+                    ControlFlow::Continue(())
+                }
+            })
+            .run(async || {
+                count += 1;
+                if count == 1 {
+                    Err::<(), _>("transient".to_string())
+                } else {
+                    Err("permanent".to_string())
+                }
+            })
+            .await;
+        assert_eq!(count, 2);
+        assert_eq!(result, Err("permanent".to_string()));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,7 @@ impl Retry {
     ///
     /// Panics if the number of attempts is set to `0`, or the base delay is
     /// incorrectly set to a negative duration.
-    pub async fn run<T, E: Debug>(
-        self,
-        func: impl AsyncFnMut() -> Result<T, E>,
-    ) -> Result<T, E> {
+    pub async fn run<T, E: Debug>(self, func: impl AsyncFnMut() -> Result<T, E>) -> Result<T, E> {
         let name = self.name;
         self.on_error(|err: E, _attempt, _total| {
             warn!(?err, "failed retryable operation {}, retrying", name);
@@ -124,10 +121,7 @@ impl<F> RetryWith<F> {
     ///
     /// Panics if the number of attempts is set to `0`, or the base delay is
     /// incorrectly set to a negative duration.
-    pub async fn run<T, E>(
-        self,
-        mut func: impl AsyncFnMut() -> Result<T, E>,
-    ) -> Result<T, E>
+    pub async fn run<T, E>(self, mut func: impl AsyncFnMut() -> Result<T, E>) -> Result<T, E>
     where
         F: FnMut(E, u32, u32),
     {
@@ -250,11 +244,7 @@ mod tests {
             .on_error(|_: (), _, _| {})
             .run(async || {
                 count += 1;
-                if count < 3 {
-                    Err::<(), ()>(())
-                } else {
-                    Ok(())
-                }
+                if count < 3 { Err::<(), ()>(()) } else { Ok(()) }
             })
             .await;
         assert!(result.is_ok());


### PR DESCRIPTION
## Summary

- Add `Retry::on_error(handler)` builder method that returns a `RetryWith<F>`, allowing callers to customize how retry errors are handled
- Useful for polling use cases where errors are expected and the default `warn!` logging is too noisy
- `Retry::run()` is unchanged — it delegates to `RetryWith::run` with the existing `warn!` behavior
- `RetryWith::run` does not require `E: Debug`, since the caller controls error formatting

### Usage

```rust
// Silence errors entirely
retry.on_error(|_, _, _| {}).run(func).await

// Log at debug level instead of warn
retry.on_error(|err, attempt, total| {
    debug!(?err, "attempt {attempt}/{total}");
}).run(func).await

// Existing behavior unchanged
retry.run(func).await
```

## Test plan

- [x] Existing tests pass unchanged
- [x] New test: custom handler receives correct (attempt, total) args
- [x] New test: silent handler suppresses all logging
- [x] New test: error types without `Debug` work with `on_error`
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)